### PR TITLE
Revisão e unificação das classes css

### DIFF
--- a/src/components/DashboardFrame.vue
+++ b/src/components/DashboardFrame.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dashboard-frame" ref="rootEl">
+  <div class="snap-section" ref="rootEl">
     <div v-if="title" class="frame-header">
       <h1 v-if="title">
         <span class="title-anchor-wrapper">
@@ -163,7 +163,7 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-.dashboard-frame {
+.snap-section {
   display: flex;
   flex-direction: column;
   height: 96vh;

--- a/src/components/SnapContainer.vue
+++ b/src/components/SnapContainer.vue
@@ -117,7 +117,7 @@ const sectionVisible = (id: string) => {
 provide('sectionVisible', sectionVisible)
 
 const updateDashboardRefs = (children: HTMLElement[]) => {
-  dashboardEls.value = children.filter(child => child.classList.contains('dashboard-frame'))
+  dashboardEls.value = children.filter(child => child.classList.contains('snap-section'))
   if (!dashboardEls.value.length) {
     activeDashboard.value = 0
     return

--- a/src/components/VideoFrame.vue
+++ b/src/components/VideoFrame.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dashboard-frame" ref="rootEl">
+  <div class="snap-section" ref="rootEl">
     <div class="iframe-wrapper">
       <iframe
         :src="embedSrc"
@@ -127,7 +127,7 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-.dashboard-frame {
+.snap-section {
   display: flex;
   flex-direction: column;
   height: 96vh;

--- a/src/views/TechGuideView.vue
+++ b/src/views/TechGuideView.vue
@@ -97,7 +97,7 @@ function select(id: string) {
   box-shadow: 0 0.625rem 1.75rem rgba(0, 0, 0, 0.32);
 }
 
-.feature-video :deep(.dashboard-frame) {
+.feature-video :deep(.snap-section) {
   position: absolute;
   inset: 0;
   padding: 0;


### PR DESCRIPTION
Aplicação agora usa uma classe única snap-section para todas as seções de tela cheia, e atualizei cada componente e estilo que dependia de .dashboard-frame.

Resolve #196 